### PR TITLE
Remove auto-detection and require explicit edition input

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ steps:
 - uses: liquibase/setup-liquibase@v1
   with:
     version: 'latest'
+    edition: 'oss'
 - run: liquibase --version
 ```
 
@@ -26,7 +27,7 @@ steps:
 - **Edition Support**: Works with both OSS and Pro editions
 - **Caching**: Optional caching for faster workflow runs
 - **Cross-Platform**: Supports Linux, Windows, and macOS runners
-- **Auto-Detection**: Automatically detects Pro edition when license key is provided
+- **Environment Variables**: Supports LIQUIBASE_LICENSE_KEY environment variable for Pro edition
 
 ## Usage Examples
 
@@ -38,6 +39,7 @@ steps:
 - uses: liquibase/setup-liquibase@v1
   with:
     version: 'latest'
+    edition: 'oss'
 - run: liquibase --version
 ```
 
@@ -62,7 +64,8 @@ steps:
   with:
     version: 'latest'
     edition: 'pro'
-    license-key: ${{ secrets.LICENSE_KEY }}
+  env:
+    LIQUIBASE_LICENSE_KEY: ${{ secrets.LIQUIBASE_LICENSE_KEY }}
 - run: liquibase update --changelog-file=changelog.xml --url=jdbc:h2:mem:test
 ```
 
@@ -83,8 +86,8 @@ steps:
 | Input | Description | Required | Default |
 |-------|-------------|----------|---------|
 | `version` | Version of Liquibase to install. Supports specific versions (e.g., "4.25.0"), version ranges (e.g., "^4.20"), or "latest" | No | `latest` |
-| `edition` | Edition to install: "oss" (Open Source) or "pro" (Professional) | No | `oss` |
-| `license-key` | License key for Liquibase Pro. Required when edition is "pro". Store this securely in GitHub Secrets. | No | |
+| `edition` | Edition to install: "oss" (Open Source) or "pro" (Professional) | Yes | |
+| `license-key` | License key for Liquibase Pro. Required when edition is "pro". Can be provided via this input or LIQUIBASE_LICENSE_KEY environment variable. Store this securely in GitHub Secrets. | No | |
 | `cache` | Enable caching of downloaded Liquibase installations to improve workflow performance on subsequent runs | No | `false` |
 | `check-latest` | Check for the latest available version that satisfies the version specification, even if a cached version exists. Note: This will bypass the cache if enabled. | No | `false` |
 
@@ -132,25 +135,27 @@ If you want to ensure you're always using the latest version that satisfies your
 
 ## Pro Edition Support
 
-The action supports both Liquibase OSS and Pro editions. The Pro edition requires a valid license key.
+The action supports both Liquibase OSS and Pro editions. The Pro edition requires a valid license key and must be explicitly specified using `edition: 'pro'`.
 
-The edition can be specified in two ways:
-1. Explicitly using the `edition: 'pro'` input
-2. Implicitly by providing a `license-key` (the action will auto-detect Pro edition)
+The license key can be provided in two ways:
+1. Using the `license-key` input parameter
+2. Using the `LIQUIBASE_LICENSE_KEY` environment variable (recommended)
 
 ```yaml
-# Explicit Pro edition
+# Using license-key input
 - uses: liquibase/setup-liquibase@v1
   with:
     version: 'latest'
     edition: 'pro'
-    license-key: ${{ secrets.LICENSE_KEY }}
+    license-key: ${{ secrets.LIQUIBASE_LICENSE_KEY }}
 
-# Auto-detected Pro edition
+# Using environment variable (recommended)
 - uses: liquibase/setup-liquibase@v1
   with:
     version: 'latest'
-    license-key: ${{ secrets.LICENSE_KEY }}
+    edition: 'pro'
+  env:
+    LIQUIBASE_LICENSE_KEY: ${{ secrets.LIQUIBASE_LICENSE_KEY }}
 ```
 
 ## Complete Workflow Examples
@@ -191,6 +196,8 @@ on: [push]
 jobs:
   database-operations:
     runs-on: ubuntu-latest
+    env:
+      LIQUIBASE_LICENSE_KEY: ${{ secrets.LIQUIBASE_LICENSE_KEY }}
     steps:
     - uses: actions/checkout@v4
     
@@ -198,7 +205,6 @@ jobs:
       with:
         version: '4.25.0'
         edition: 'pro'
-        license-key: ${{ secrets.LICENSE_KEY }}
         cache: true
     
     - name: Validate Changelog
@@ -234,6 +240,7 @@ jobs:
     - uses: liquibase/setup-liquibase@v1
       with:
         version: ${{ matrix.liquibase-version }}
+        edition: 'oss'
         cache: true
     
     - name: Test Migration
@@ -245,7 +252,7 @@ jobs:
 ## Security Considerations
 
 - Store sensitive information like license keys in GitHub Secrets
-- Use `license-key: ${{ secrets.LICENSE_KEY }}`
+- Use `license-key: ${{ secrets.LIQUIBASE_LICENSE_KEY }}` or `LIQUIBASE_LICENSE_KEY: ${{ secrets.LIQUIBASE_LICENSE_KEY }}`
 - Never commit license keys directly to your repository
 
 ## Migration from Legacy Actions
@@ -267,6 +274,7 @@ If you're migrating from the official Liquibase GitHub Actions, here's how to co
 - uses: liquibase/setup-liquibase@v1
   with:
     version: 'latest'
+    edition: 'oss'
 - run: liquibase update \
     --changelog-file=changelog.xml \
     --url=jdbc:h2:mem:test \

--- a/__tests__/unit/installer.test.ts
+++ b/__tests__/unit/installer.test.ts
@@ -3,7 +3,7 @@ import { getDownloadUrl } from '../../src/installer';
 describe('getDownloadUrl', () => {
   it('should construct correct OSS URL for latest version', () => {
     const version = '4.32.0';
-    const url = getDownloadUrl(version);
+    const url = getDownloadUrl(version, 'oss');
     expect(url).toBe(`https://package.liquibase.com/downloads/cli/liquibase/releases/download/v${version}/liquibase-${version}.tar.gz`);
   });
 
@@ -18,7 +18,7 @@ describe('getDownloadUrl', () => {
     Object.defineProperty(process, 'platform', { value: 'win32' });
     
     const version = '4.32.0';
-    const url = getDownloadUrl(version);
+    const url = getDownloadUrl(version, 'oss');
     expect(url).toBe(`https://package.liquibase.com/downloads/cli/liquibase/releases/download/v${version}/liquibase-${version}.zip`);
     
     Object.defineProperty(process, 'platform', { value: originalPlatform });
@@ -29,7 +29,7 @@ describe('getDownloadUrl', () => {
     Object.defineProperty(process, 'platform', { value: 'linux' });
     
     const version = '4.32.0';
-    const url = getDownloadUrl(version);
+    const url = getDownloadUrl(version, 'oss');
     expect(url).toBe(`https://package.liquibase.com/downloads/cli/liquibase/releases/download/v${version}/liquibase-${version}.tar.gz`);
     
     Object.defineProperty(process, 'platform', { value: originalPlatform });

--- a/action.yml
+++ b/action.yml
@@ -18,11 +18,11 @@ inputs:
     default: 'latest'
   
   edition:
-    description: 'Edition to install: "oss" (Open Source) or "pro" (Professional with additional features). If not specified, auto-detects based on license key presence.'
-    required: false
+    description: 'Edition to install: "oss" (Open Source) or "pro" (Professional with additional features)'
+    required: true
   
   license-key:
-    description: 'License key for Liquibase Pro edition. Required when edition is "pro". Store this securely in GitHub Secrets.'
+    description: 'License key for Liquibase Pro edition. Required when edition is "pro". Can be provided via this input or LIQUIBASE_LICENSE_KEY environment variable. Store this securely in GitHub Secrets.'
     required: false
   
   cache:

--- a/examples/basic-usage.yml
+++ b/examples/basic-usage.yml
@@ -10,6 +10,7 @@ jobs:
       - uses: jnewton03/setup-liquibase@v1
         with:
           version: 'latest'
+          edition: 'oss'
           cache: true
       
       - name: Run Liquibase Update

--- a/examples/pro-usage.yml
+++ b/examples/pro-usage.yml
@@ -4,6 +4,8 @@ on: [push]
 jobs:
   test:
     runs-on: ubuntu-latest
+    env:
+      LIQUIBASE_LICENSE_KEY: ${{ secrets.LIQUIBASE_LICENSE_KEY }}
     steps:
       - uses: actions/checkout@v4
       
@@ -11,7 +13,6 @@ jobs:
         with:
           version: 'latest'
           edition: 'pro'
-          license-key: ${{ secrets.LIQUIBASE_LICENSE_KEY }}
           cache: true
       
       - name: Run Pro Features

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,21 +20,24 @@ async function run(): Promise<void> {
     // Extract input parameters from the GitHub Action context
     const version = core.getInput('version') || 'latest';
     const editionInput = core.getInput('edition');
-    const licenseKey = core.getInput('license-key');
+    const licenseKeyInput = core.getInput('license-key');
     const cache = core.getBooleanInput('cache');
     const checkLatest = core.getBooleanInput('check-latest');
 
-    // Validate edition input if provided, otherwise allow auto-detection
-    let edition: 'oss' | 'pro' | undefined;
-    if (editionInput) {
-      if (editionInput !== 'oss' && editionInput !== 'pro') {
-        throw new Error('Edition must be either "oss" or "pro"');
-      }
-      edition = editionInput as 'oss' | 'pro';
+    // Validate required edition input
+    if (!editionInput) {
+      throw new Error('Edition input is required. Must be either "oss" or "pro"');
     }
+    if (editionInput !== 'oss' && editionInput !== 'pro') {
+      throw new Error('Edition must be either "oss" or "pro"');
+    }
+    const edition = editionInput as 'oss' | 'pro';
+
+    // Get license key from input or environment variable
+    const licenseKey = licenseKeyInput || process.env.LIQUIBASE_LICENSE_KEY;
 
     // Log the setup configuration for debugging purposes
-    core.info(`Setting up Liquibase version ${version}${edition ? ` (${edition} edition)` : ' (auto-detecting edition)'}`);
+    core.info(`Setting up Liquibase version ${version} (${edition} edition)`);
 
     // Execute the main installation logic
     const result = await setupLiquibase({

--- a/src/installer.ts
+++ b/src/installer.ts
@@ -24,9 +24,9 @@ import { VersionResolver } from './version-resolver';
 export interface LiquibaseSetupOptions {
   /** Version to install (specific version, range, or 'latest') */
   version: string;
-  /** Edition to install: 'oss' for Open Source, 'pro' for Professional (auto-detected if not specified) */
-  edition?: 'oss' | 'pro';
-  /** License key for Pro edition (presence auto-detects Pro edition if edition not specified) */
+  /** Edition to install: 'oss' for Open Source, 'pro' for Professional */
+  edition: 'oss' | 'pro';
+  /** License key for Pro edition. Can be provided via input or LIQUIBASE_LICENSE_KEY environment variable */
   licenseKey?: string;
   /** Whether to cache the downloaded installation */
   cache: boolean;
@@ -60,14 +60,7 @@ export interface LiquibaseSetupResult {
  * @returns Promise resolving to the setup result with version and path
  */
 export async function setupLiquibase(options: LiquibaseSetupOptions): Promise<LiquibaseSetupResult> {
-  const { version, licenseKey, cache, checkLatest } = options;
-  let { edition } = options;
-  
-  // Auto-detect edition based on license key presence if not explicitly specified
-  if (!edition) {
-    edition = licenseKey ? 'pro' : 'oss';
-    core.info(`Auto-detected Liquibase edition: ${edition} (based on ${licenseKey ? 'license key presence' : 'no license key'})`);
-  }
+  const { version, edition, licenseKey, cache, checkLatest } = options;
   
   // Validate Pro edition requirements
   if (edition === 'pro' && !licenseKey) {
@@ -137,7 +130,7 @@ export async function setupLiquibase(options: LiquibaseSetupOptions): Promise<Li
  * @param edition - Edition to download ('oss' or 'pro')
  * @returns Download URL for the specified version using Scarf proxy
  */
-export function getDownloadUrl(version: string, edition: 'oss' | 'pro' = 'oss'): string {
+export function getDownloadUrl(version: string, edition: 'oss' | 'pro'): string {
   const ext = process.platform === 'win32' ? 'zip' : 'tar.gz';
   if (edition === 'pro') {
     return `https://package.liquibase.com/downloads/cli/liquibase-pro/releases/download/v${version}/liquibase-pro-${version}.${ext}`;


### PR DESCRIPTION
## Summary
- Remove auto-detection logic that inferred Pro edition from license key presence
- Make edition parameter required and explicitly specified in all usage
- Update examples to use LIQUIBASE_LICENSE_KEY environment variable for better alignment with CLI usage patterns

## Changes Made
- **Breaking Change**: `edition` parameter is now required in `action.yml`
- Removed auto-detection logic from `src/installer.ts` and `src/index.ts`
- Updated examples to demonstrate `LIQUIBASE_LICENSE_KEY` environment variable usage
- License key can be provided via input parameter or `LIQUIBASE_LICENSE_KEY` env var
- Updated all documentation and README examples
- Fixed unit tests to work with required edition parameter

## Migration Guide
Users need to add `edition: 'oss'` or `edition: 'pro'` to their workflow configuration:

**Before:**
```yaml
- uses: jnewton03/setup-liquibase@v1
  with:
    version: 'latest'
```

**After:**
```yaml
- uses: jnewton03/setup-liquibase@v1
  with:
    version: 'latest'
    edition: 'oss'
```

For Pro usage, the recommended approach is now:
```yaml
- uses: jnewton03/setup-liquibase@v1
  with:
    version: 'latest'
    edition: 'pro'
  env:
    LIQUIBASE_LICENSE_KEY: ${{ secrets.LIQUIBASE_LICENSE_KEY }}
```

## Test plan
- [x] All existing tests pass with updated edition parameter requirements
- [x] TypeScript compilation succeeds
- [x] Linting passes
- [x] Examples updated to reflect new usage patterns
- [x] Documentation updated throughout README

🤖 Generated with [Claude Code](https://claude.ai/code)