### PR TITLE
Remove check-latest and license-key inputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ steps:
 
 ## Features
 
-- **Version Control**: Install specific versions or use version ranges
+- **Version Control**: Install specific versions (4.32.0+)
 - **Edition Support**: Works with both OSS and Pro editions
 - **Caching**: Optional caching for faster workflow runs
 - **Cross-Platform**: Supports Linux, Windows, and macOS runners
@@ -50,7 +50,7 @@ steps:
 - uses: actions/checkout@v4
 - uses: liquibase/setup-liquibase@v1
   with:
-    version: '4.25.0'
+    version: '4.32.0'
     edition: 'oss'
 - run: liquibase update --changelog-file=changelog.xml --url=jdbc:h2:mem:test
 ```
@@ -69,14 +69,14 @@ steps:
 - run: liquibase update --changelog-file=changelog.xml --url=jdbc:h2:mem:test
 ```
 
-### Version Range with Caching
+### With Caching
 
 ```yaml
 steps:
 - uses: actions/checkout@v4
 - uses: liquibase/setup-liquibase@v1
   with:
-    version: '^4.20'
+    version: '4.32.0'
     cache: true
 - run: liquibase --version
 ```
@@ -87,9 +87,7 @@ steps:
 |-------|-------------|----------|---------|
 | `version` | Specific version of Liquibase to install (e.g., "4.32.0"). Must be 4.32.0 or higher. | Yes | |
 | `edition` | Edition to install: "oss" (Open Source) or "pro" (Professional) | Yes | |
-| `license-key` | License key for Liquibase Pro. Required when edition is "pro". Can be provided via this input or LIQUIBASE_LICENSE_KEY environment variable. Store this securely in GitHub Secrets. | No | |
 | `cache` | Enable caching of downloaded Liquibase installations to improve workflow performance on subsequent runs | No | `false` |
-| `check-latest` | Check for the latest available version that satisfies the version specification, even if a cached version exists. Note: This will bypass the cache if enabled. | No | `false` |
 
 ## Outputs
 
@@ -122,33 +120,20 @@ The cache is unique per:
 - Version
 - Edition (OSS vs Pro)
 
-If you want to ensure you're always using the latest version that satisfies your requirements, you can set `check-latest: true`. This will bypass the cache and download the latest version.
-
 ```yaml
 - uses: liquibase/setup-liquibase@v1
   with:
-    version: '4.25.0'
+    version: '4.32.0'
     cache: true
-    # check-latest: true  # Only use this if you want to bypass the cache
 ```
 
 ## Pro Edition Support
 
 The action supports both Liquibase OSS and Pro editions. The Pro edition requires a valid license key and must be explicitly specified using `edition: 'pro'`.
 
-The license key can be provided in two ways:
-1. Using the `license-key` input parameter
-2. Using the `LIQUIBASE_LICENSE_KEY` environment variable (recommended)
+The license key must be provided using the `LIQUIBASE_LICENSE_KEY` environment variable:
 
 ```yaml
-# Using license-key input
-- uses: liquibase/setup-liquibase@v1
-  with:
-    version: '4.32.0'
-    edition: 'pro'
-    license-key: ${{ secrets.LIQUIBASE_LICENSE_KEY }}
-
-# Using environment variable (recommended)
 - uses: liquibase/setup-liquibase@v1
   with:
     version: '4.32.0'
@@ -202,7 +187,7 @@ jobs:
     
     - uses: liquibase/setup-liquibase@v1
       with:
-        version: '4.25.0'
+        version: '4.32.0'
         edition: 'pro'
         cache: true
     
@@ -251,7 +236,7 @@ jobs:
 ## Security Considerations
 
 - Store sensitive information like license keys in GitHub Secrets
-- Use `license-key: ${{ secrets.LIQUIBASE_LICENSE_KEY }}` or `LIQUIBASE_LICENSE_KEY: ${{ secrets.LIQUIBASE_LICENSE_KEY }}`
+- Use `LIQUIBASE_LICENSE_KEY: ${{ secrets.LIQUIBASE_LICENSE_KEY }}` in the environment
 - Never commit license keys directly to your repository
 
 ## Migration from Legacy Actions

--- a/__tests__/integration/installer.test.ts
+++ b/__tests__/integration/installer.test.ts
@@ -29,8 +29,7 @@ describe('setupLiquibase Integration', () => {
       const result = await setupLiquibase({
         version: '4.32.0',
         edition: 'oss',
-        cache: true,
-        checkLatest: false
+        cache: true
       });
       
       expect(tc.find).toHaveBeenCalledWith('liquibase-oss', '4.32.0');
@@ -47,8 +46,7 @@ describe('setupLiquibase Integration', () => {
       const result = await setupLiquibase({
         version: '4.32.0',
         edition: 'oss',
-        cache: true,
-        checkLatest: false
+        cache: true
       });
       
       expect(tc.find).toHaveBeenCalledWith('liquibase-oss', '4.32.0');
@@ -58,22 +56,20 @@ describe('setupLiquibase Integration', () => {
       expect(result.path).toBe('/path/to/cached/dir');
     });
 
-    it('should bypass cache when check-latest is true', async () => {
-      (tc.find as jest.Mock).mockReturnValue('/path/to/cached/liquibase');
+    it('should not download when cache is disabled', async () => {
+      (tc.find as jest.Mock).mockReturnValue('');
       (tc.downloadTool as jest.Mock).mockResolvedValue('/path/to/downloaded/file');
-      (tc.extractTar as jest.Mock).mockResolvedValue('/path/to/cached/dir');
-      (tc.cacheDir as jest.Mock).mockResolvedValue('/path/to/cached/dir');
+      (tc.extractTar as jest.Mock).mockResolvedValue('/path/to/extract/dir');
       
       const result = await setupLiquibase({
         version: '4.32.0',
         edition: 'oss',
-        cache: true,
-        checkLatest: true
+        cache: false
       });
       
-      // expect(tc.find).not.toHaveBeenCalled();
       expect(tc.downloadTool).toHaveBeenCalled();
-      expect(result.path).toBe('/path/to/cached/dir');
+      expect(tc.cacheDir).not.toHaveBeenCalled();
+      expect(result.path).toBe('/path/to/extract/dir');
     });
   });
 
@@ -82,8 +78,7 @@ describe('setupLiquibase Integration', () => {
       await expect(setupLiquibase({
         version: '4.32.0',
         edition: 'pro',
-        cache: false,
-        checkLatest: false
+        cache: false
       })).rejects.toThrow('License key is required for Liquibase Pro edition');
     });
 
@@ -99,8 +94,7 @@ describe('setupLiquibase Integration', () => {
         version: '4.32.0',
         edition: 'pro',
         licenseKey: 'test-license-key',
-        cache: false,
-        checkLatest: false
+        cache: false
       });
       
       expect(fs.promises.writeFile).toHaveBeenCalledWith(
@@ -122,8 +116,7 @@ describe('setupLiquibase Integration', () => {
       await setupLiquibase({
         version: '4.32.0',
         edition: 'oss',
-        cache: false,
-        checkLatest: false
+        cache: false
       });
       
       expect(tc.extractZip).toHaveBeenCalled();
@@ -143,8 +136,7 @@ describe('setupLiquibase Integration', () => {
       await setupLiquibase({
         version: '4.32.0',
         edition: 'oss',
-        cache: false,
-        checkLatest: false
+        cache: false
       });
       
       expect(tc.extractTar).toHaveBeenCalled();
@@ -161,8 +153,7 @@ describe('setupLiquibase Integration', () => {
       await expect(setupLiquibase({
         version: '4.32.0',
         edition: 'oss',
-        cache: false,
-        checkLatest: false
+        cache: false
       })).rejects.toThrow('Download failed');
     });
 
@@ -173,8 +164,7 @@ describe('setupLiquibase Integration', () => {
       await expect(setupLiquibase({
         version: '4.32.0',
         edition: 'oss',
-        cache: false,
-        checkLatest: false
+        cache: false
       })).rejects.toThrow('Extraction failed');
     });
 
@@ -187,8 +177,7 @@ describe('setupLiquibase Integration', () => {
       await expect(setupLiquibase({
         version: '4.32.0',
         edition: 'oss',
-        cache: false,
-        checkLatest: false
+        cache: false
       })).rejects.toThrow('Failed to validate Liquibase installation');
     });
   });

--- a/__tests__/unit/installer.test.ts
+++ b/__tests__/unit/installer.test.ts
@@ -63,8 +63,7 @@ describe('setupLiquibase', () => {
     const options = {
       version: '4.25.0', // Below 4.32.0
       edition: 'oss' as const,
-      cache: false,
-      checkLatest: false
+      cache: false
     };
 
     await expect(setupLiquibase(options)).rejects.toThrow(
@@ -76,8 +75,7 @@ describe('setupLiquibase', () => {
     const options = {
       version: 'invalid-version',
       edition: 'oss' as const,
-      cache: false,
-      checkLatest: false
+      cache: false
     };
 
     await expect(setupLiquibase(options)).rejects.toThrow(
@@ -89,8 +87,7 @@ describe('setupLiquibase', () => {
     const options = {
       version: '4.32.0',
       edition: 'pro' as const,
-      cache: false,
-      checkLatest: false
+      cache: false
     };
 
     await expect(setupLiquibase(options)).rejects.toThrow(

--- a/action.yml
+++ b/action.yml
@@ -20,17 +20,8 @@ inputs:
     description: 'Edition to install: "oss" (Open Source) or "pro" (Professional with additional features)'
     required: true
   
-  license-key:
-    description: 'License key for Liquibase Pro edition. Required when edition is "pro". Can be provided via this input or LIQUIBASE_LICENSE_KEY environment variable. Store this securely in GitHub Secrets.'
-    required: false
-  
   cache:
     description: 'Enable caching of downloaded Liquibase installations to improve workflow performance on subsequent runs'
-    required: false
-    default: 'false'
-  
-  check-latest:
-    description: 'Check for the latest available version that satisfies the version specification, even if a cached version exists'
     required: false
     default: 'false'
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,9 +20,7 @@ async function run(): Promise<void> {
     // Extract input parameters from the GitHub Action context
     const version = core.getInput('version');
     const editionInput = core.getInput('edition');
-    const licenseKeyInput = core.getInput('license-key');
     const cache = core.getBooleanInput('cache');
-    const checkLatest = core.getBooleanInput('check-latest');
 
     // Validate required version input
     if (!version) {
@@ -38,8 +36,8 @@ async function run(): Promise<void> {
     }
     const edition = editionInput as 'oss' | 'pro';
 
-    // Get license key from input or environment variable
-    const licenseKey = licenseKeyInput || process.env.LIQUIBASE_LICENSE_KEY;
+    // Get license key from environment variable only
+    const licenseKey = process.env.LIQUIBASE_LICENSE_KEY;
 
     // Log the setup configuration for debugging purposes
     core.info(`Setting up Liquibase version ${version} (${edition} edition)`);
@@ -49,8 +47,7 @@ async function run(): Promise<void> {
       version,
       edition,
       licenseKey,
-      cache,
-      checkLatest
+      cache
     });
 
     // Set output values that other workflow steps can reference

--- a/src/installer.ts
+++ b/src/installer.ts
@@ -26,12 +26,10 @@ export interface LiquibaseSetupOptions {
   version: string;
   /** Edition to install: 'oss' for Open Source, 'pro' for Professional */
   edition: 'oss' | 'pro';
-  /** License key for Pro edition. Can be provided via input or LIQUIBASE_LICENSE_KEY environment variable */
+  /** License key for Pro edition from LIQUIBASE_LICENSE_KEY environment variable */
   licenseKey?: string;
   /** Whether to cache the downloaded installation */
   cache: boolean;
-  /** Whether to check for the latest version even if cached version exists */
-  checkLatest: boolean;
 }
 
 /**
@@ -60,7 +58,7 @@ export interface LiquibaseSetupResult {
  * @returns Promise resolving to the setup result with version and path
  */
 export async function setupLiquibase(options: LiquibaseSetupOptions): Promise<LiquibaseSetupResult> {
-  const { version, edition, licenseKey, cache, checkLatest } = options;
+  const { version, edition, licenseKey, cache } = options;
   
   // Validate version requirement
   if (!semver.valid(version)) {
@@ -85,8 +83,8 @@ export async function setupLiquibase(options: LiquibaseSetupOptions): Promise<Li
   // Check if we already have this version cached
   let toolPath = tc.find(toolName, resolvedVersion);
   
-  // Download and install if not cached, caching is disabled, or checkLatest is true
-  if (!toolPath || !cache || checkLatest) {
+  // Download and install if not cached or caching is disabled
+  if (!toolPath || !cache) {
     core.info(`Installing Liquibase ${edition} version ${resolvedVersion}`);
     
     // Get the appropriate download URL for this version and edition


### PR DESCRIPTION
This pull request removes the `checkLatest` option and simplifies the handling of the `licenseKey` input for Liquibase setup in both unit tests and integration tests, as well as the core implementation. The primary focus is on streamlining the codebase and ensuring consistent behavior across different files.

### Removal of `checkLatest` and Input Simplifications:
* **Integration Tests (`__tests__/integration/installer.test.ts`)**: Removed `checkLatest` from all test cases, updated test logic to reflect changes in caching behavior, and simplified expectations for download and extraction processes. [[1]](diffhunk://#diff-c4c35bd5511774a0ddc1acbdd569871057621eed6f1b67e592714e6d8396122fL32-R32) [[2]](diffhunk://#diff-c4c35bd5511774a0ddc1acbdd569871057621eed6f1b67e592714e6d8396122fL61-R72) [[3]](diffhunk://#diff-c4c35bd5511774a0ddc1acbdd569871057621eed6f1b67e592714e6d8396122fL164-R156) [[4]](diffhunk://#diff-c4c35bd5511774a0ddc1acbdd569871057621eed6f1b67e592714e6d8396122fL176-R167)
* **Unit Tests (`__tests__/unit/installer.test.ts`)**: Updated test cases to remove `checkLatest` and adjusted expectations for invalid version handling and caching. [[1]](diffhunk://#diff-3fb7d29d03a36d2b1d3e0b763dda0374be4ae9e5e76f73073ee514d9bafc2fcbL66-R66) [[2]](diffhunk://#diff-3fb7d29d03a36d2b1d3e0b763dda0374be4ae9e5e76f73073ee514d9bafc2fcbL79-R78) [[3]](diffhunk://#diff-3fb7d29d03a36d2b1d3e0b763dda0374be4ae9e5e76f73073ee514d9bafc2fcbL92-R90)

### Updates to Action Inputs:
* **`action.yml`**: Removed `checkLatest` and `license-key` inputs, simplifying the configuration for Liquibase setup.

### Core Implementation Changes:
* **`src/index.ts`**: Removed `checkLatest` input and updated `licenseKey` to be sourced only from the environment variable. [[1]](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80L23-L25) [[2]](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80L41-R40) [[3]](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80L52-R50)
* **`src/installer.ts`**: Updated the `LiquibaseSetupOptions` interface to remove `checkLatest` and adjusted the setup logic to reflect the absence of this option. [[1]](diffhunk://#diff-36a9847d245bd66dd946fe257334eb7bbe0c728d37d53df8b8173c7e3eecd5b2L29-L34) [[2]](diffhunk://#diff-36a9847d245bd66dd946fe257334eb7bbe0c728d37d53df8b8173c7e3eecd5b2L63-R61) [[3]](diffhunk://#diff-36a9847d245bd66dd946fe257334eb7bbe0c728d37d53df8b8173c7e3eecd5b2L88-R87)